### PR TITLE
Bump version of arrow to 0.12 , use Error instead of ArrowError

### DIFF
--- a/arrow2_convert/Cargo.toml
+++ b/arrow2_convert/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/DataEngineeringLabs/arrow2-convert"
 description = "Convert between nested rust types and Arrow with arrow2"
 
 [dependencies]
-arrow2 = "0.10"
+arrow2 = "0.12"
 arrow2_convert_derive = { version = "0.1.0", path = "../arrow2_convert_derive", optional = true }
 chrono = { version = "0.4", default_features = false, features = ["std"] }
 err-derive = "0.3"

--- a/arrow2_convert/src/deserialize.rs
+++ b/arrow2_convert/src/deserialize.rs
@@ -290,7 +290,7 @@ where
     for<'b> &'b <ArrowType as ArrowDeserialize>::ArrayType: IntoIterator,
 {
     if &<ArrowType as ArrowField>::data_type() != arr.data_type() {
-        Err(arrow2::error::ArrowError::InvalidArgumentError(
+        Err(arrow2::error::Error::InvalidArgumentError(
             "Data type mismatch".to_string(),
         ))
     } else {


### PR DESCRIPTION
This bumps Arrow2 to 0.12 and changes Error over from ArrowError.