### PR TITLE
Serialize escaped Rust identifiers unescaped.

### DIFF
--- a/arrow2_convert/tests/test_round_trip.rs
+++ b/arrow2_convert/tests/test_round_trip.rs
@@ -234,3 +234,22 @@ fn test_primitive_type_vec() {
     let round_trip: Vec<Option<Vec<u8>>> = b.try_into_collection().unwrap();
     assert_eq!(original_array, round_trip);
 }
+
+#[test]
+fn test_escaped_name() {
+    #[derive(ArrowField, Debug, Eq, PartialEq)]
+    struct EscapedName {
+        r#type: bool,
+    }
+    let array = [EscapedName { r#type: true }, EscapedName { r#type: false }];
+    let b: Box<dyn Array> = array.try_into_arrow().unwrap();
+    let ty = b.data_type();
+    match ty {
+        DataType::Struct(s) => {
+            assert_eq!(s[0].name, "type");
+        }
+        _ => unreachable!(),
+    }
+    let round_trip: Vec<EscapedName> = b.try_into_collection().unwrap();
+    assert_eq!(array.as_slice(), round_trip.as_slice());
+}

--- a/arrow2_convert_derive/src/derive_struct.rs
+++ b/arrow2_convert_derive/src/derive_struct.rs
@@ -386,12 +386,5 @@ pub fn expand(input: DeriveStruct) -> TokenStream {
 
 /// Removes the 'r#' from escaped identifiers.
 fn strip_escape_prefix(name: &str) -> &str {
-    if name.starts_with("r#") {
-        if name.len() == 2 {
-            return "";
-        }
-        &name[2..]
-    } else {
-        name
-    }
+    name.strip_prefix("r#").unwrap_or(name)
 }

--- a/arrow2_convert_derive/src/derive_struct.rs
+++ b/arrow2_convert_derive/src/derive_struct.rs
@@ -28,7 +28,12 @@ pub fn expand(input: DeriveStruct) -> TokenStream {
 
     let field_names_str = field_names
         .iter()
-        .map(|field| syn::LitStr::new(&format!("{}", field), proc_macro2::Span::call_site()))
+        .map(|field| {
+            syn::LitStr::new(
+                strip_escape_prefix(&format!("{}", field)),
+                proc_macro2::Span::call_site(),
+            )
+        })
         .collect::<Vec<_>>();
 
     let field_indices = field_names
@@ -377,4 +382,16 @@ pub fn expand(input: DeriveStruct) -> TokenStream {
     }
 
     generated
+}
+
+/// Removes the 'r#' from escaped identifiers.
+fn strip_escape_prefix(name: &str) -> &str {
+    if name.starts_with("r#") {
+        if name.len() == 2 {
+            return "";
+        }
+        &name[2..]
+    } else {
+        name
+    }
 }


### PR DESCRIPTION
I believe this is the correct behaviour for this case.