### PR TITLE
Fix #65 Upgrade to arrow2 v0.14

### DIFF
--- a/arrow2_convert/Cargo.toml
+++ b/arrow2_convert/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/DataEngineeringLabs/arrow2-convert"
 description = "Convert between nested rust types and Arrow with arrow2"
 
 [dependencies]
-arrow2 = "0.13"
+arrow2 = "0.14.1"
 arrow2_convert_derive = { version = "0.3.0", path = "../arrow2_convert_derive", optional = true }
 chrono = { version = "0.4", default_features = false, features = ["std"] }
 err-derive = "0.3"


### PR DESCRIPTION
- Remove ArrowMutableArray trait since arrow2's mutable array now defines `reserve`