### PR TITLE
Properly support sliced unions

### DIFF
--- a/arrow2_convert/tests/test_enum.rs
+++ b/arrow2_convert/tests/test_enum.rs
@@ -87,7 +87,7 @@ fn test_nested_unit_variant() {
 }
 
 // TODO: reenable this test once slices for enums is fixed.
-//#[test]
+#[test]
 #[allow(unused)]
 fn test_slice() {
     #[derive(Debug, PartialEq, ArrowField, ArrowSerialize, ArrowDeserialize)]


### PR DESCRIPTION
I believe this resolves: https://github.com/DataEngineeringLabs/arrow2-convert/issues/53

Rather than creating and maintaining parallel iterators, this uses the `UnionArray::index()` method to find the correct offset value to deserialize from and then deserializes from a newly created slice at that location in the correct child-array. One nice aspect to this approach is it generalizes to Sparse unions since `index()` does the correct book-keeping for us.