### PR TITLE
Update to arrow2 0.16

### DIFF
--- a/arrow2_convert/Cargo.toml
+++ b/arrow2_convert/Cargo.toml
@@ -3,7 +3,7 @@ name = "arrow2_convert"
 version = "0.3.2"
 authors = [
     "Jorge Leitao <jorgecarleitao@gmail.com>",
-    "Chandra Penke <chandrapenke@gmail.com>"
+    "Chandra Penke <chandrapenke@gmail.com>",
 ]
 edition = "2021"
 license = "Apache-2.0 OR MIT"
@@ -12,7 +12,7 @@ repository = "https://github.com/DataEngineeringLabs/arrow2-convert"
 description = "Convert between nested rust types and Arrow with arrow2"
 
 [dependencies]
-arrow2 = "0.15"
+arrow2 = "0.16"
 arrow2_convert_derive = { version = "0.3.2", path = "../arrow2_convert_derive", optional = true }
 chrono = { version = "0.4", default_features = false, features = ["std"] }
 err-derive = "0.3"
@@ -22,5 +22,5 @@ trybuild = "1.0"
 arrow2_convert_derive = { version = "0.3.2", path = "../arrow2_convert_derive" }
 
 [features]
-default = [ "derive" ]
-derive = [ "arrow2_convert_derive" ]
+default = ["derive"]
+derive = ["arrow2_convert_derive"]

--- a/examples/simple/Cargo.toml
+++ b/examples/simple/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-arrow2 = "0.15"
+arrow2 = "0.16"
 arrow2_convert = { version = "0.3", path = "../../arrow2_convert" }


### PR DESCRIPTION
`arrow2` 0.16.0 was just released!

I would very much appreciate if you could release a new `arrow2-convert` as soon as you can 🙏❤️ 

PS: Thanks for such a great crate!