### PR TITLE
Enable using `Buffer<T>` for Serialize/Deserialize

### DIFF
--- a/arrow2_convert/Cargo.toml
+++ b/arrow2_convert/Cargo.toml
@@ -20,7 +20,15 @@ trybuild = "1.0"
 
 [dev-dependencies]
 arrow2_convert_derive = { version = "0.4.0", path = "../arrow2_convert_derive" }
+criterion = "0.4"
 
 [features]
 default = ["derive"]
 derive = ["arrow2_convert_derive"]
+
+[lib]
+bench = false
+
+[[bench]]
+name = "bench"
+harness = false

--- a/arrow2_convert/benches/bench.rs
+++ b/arrow2_convert/benches/bench.rs
@@ -1,0 +1,68 @@
+use arrow2::{array::Array, buffer::Buffer};
+use arrow2_convert::{
+    deserialize::TryIntoCollection, serialize::TryIntoArrow, ArrowDeserialize, ArrowField,
+    ArrowSerialize,
+};
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+
+#[derive(ArrowField, ArrowSerialize, ArrowDeserialize)]
+#[arrow_field(transparent)]
+pub struct BufStruct(Buffer<u16>);
+
+#[derive(ArrowField, ArrowSerialize, ArrowDeserialize)]
+#[arrow_field(transparent)]
+pub struct VecStruct(Vec<u16>);
+
+pub fn bench_buffer_serialize(c: &mut Criterion) {
+    let mut group = c.benchmark_group("serialize");
+    for size in [1, 10, 100, 1000, 10000].iter() {
+        group.throughput(Throughput::Elements(*size as u64));
+        group.bench_with_input(BenchmarkId::new("Buffer", size), size, |b, &size| {
+            let data = [BufStruct((0..size as u16).into_iter().collect())];
+            b.iter(|| {
+                let _: Box<dyn Array> = TryIntoArrow::try_into_arrow(black_box(&data)).unwrap();
+            });
+        });
+        group.bench_with_input(BenchmarkId::new("Vec", size), size, |b, &size| {
+            let data = [VecStruct((0..size as u16).into_iter().collect())];
+            b.iter(|| {
+                let _: Box<dyn Array> = TryIntoArrow::try_into_arrow(black_box(&data)).unwrap();
+            });
+        });
+    }
+}
+pub fn bench_buffer_deserialize(c: &mut Criterion) {
+    let mut group = c.benchmark_group("deserialize");
+    for size in [1, 10, 100, 1000, 10000].iter() {
+        group.throughput(Throughput::Elements(*size as u64));
+        group.bench_with_input(BenchmarkId::new("Buffer", size), size, |b, &size| {
+            let data: Box<dyn Array> = [BufStruct((0..size as u16).into_iter().collect())]
+                .try_into_arrow()
+                .unwrap();
+            b.iter_batched(
+                || data.clone(),
+                |data| {
+                    let _: Vec<BufStruct> =
+                        TryIntoCollection::try_into_collection(black_box(data)).unwrap();
+                },
+                criterion::BatchSize::SmallInput,
+            )
+        });
+        group.bench_with_input(BenchmarkId::new("Vec", size), size, |b, &size| {
+            let data: Box<dyn Array> = [VecStruct((0..size as u16).into_iter().collect())]
+                .try_into_arrow()
+                .unwrap();
+            b.iter_batched(
+                || data.clone(),
+                |data| {
+                    let _: Vec<VecStruct> =
+                        TryIntoCollection::try_into_collection(black_box(data)).unwrap();
+                },
+                criterion::BatchSize::SmallInput,
+            );
+        });
+    }
+}
+
+criterion_group!(benches, bench_buffer_serialize, bench_buffer_deserialize);
+criterion_main!(benches);

--- a/arrow2_convert/src/deserialize.rs
+++ b/arrow2_convert/src/deserialize.rs
@@ -1,6 +1,6 @@
 //! Implementation and traits for deserializing from Arrow.
 
-use arrow2::array::*;
+use arrow2::{array::*, buffer::Buffer, types::NativeType};
 use chrono::{NaiveDate, NaiveDateTime};
 
 use crate::field::*;
@@ -71,6 +71,7 @@ macro_rules! impl_arrow_array {
         impl ArrowArray for $array {
             type BaseArrayType = Self;
 
+            #[inline]
             fn iter_from_array_ref(b: &dyn Array) -> <&Self as IntoIterator>::IntoIter {
                 b.as_any()
                     .downcast_ref::<Self::BaseArrayType>()
@@ -211,6 +212,28 @@ where
         arrow_array_deserialize_iterator_internal::<<T as ArrowField>::Type, T>(t.deref())
             .collect::<Vec<<T as ArrowField>::Type>>()
     })
+}
+
+// Blanket implementation for Buffer
+impl<T> ArrowDeserialize for Buffer<T>
+where
+    T: ArrowDeserialize + NativeType + ArrowEnableVecForType,
+    for<'b> &'b <T as ArrowDeserialize>::ArrayType: IntoIterator
+{
+    type ArrayType = ListArray<i32>;
+
+    #[inline]
+    fn arrow_deserialize(
+        v: <&Self::ArrayType as IntoIterator>::Item,
+    ) -> Option<<Self as ArrowField>::Type> {
+        v.map(|t| {
+            t.as_any()
+                .downcast_ref::<PrimitiveArray<T>>()
+                .unwrap()
+                .values()
+                .clone()
+        })
+    }
 }
 
 // Blanket implementation for Vec

--- a/arrow2_convert/src/deserialize.rs
+++ b/arrow2_convert/src/deserialize.rs
@@ -218,7 +218,7 @@ where
 impl<T> ArrowDeserialize for Buffer<T>
 where
     T: ArrowDeserialize + NativeType + ArrowEnableVecForType,
-    for<'b> &'b <T as ArrowDeserialize>::ArrayType: IntoIterator
+    for<'b> &'b <T as ArrowDeserialize>::ArrayType: IntoIterator,
 {
     type ArrayType = ListArray<i32>;
 

--- a/arrow2_convert/src/lib.rs
+++ b/arrow2_convert/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc = include_str!("../README.md")]
+#![cfg_attr(not(target_os = "windows"), doc = include_str!("../README.md"))]
 #![deny(missing_docs)]
 #![forbid(unsafe_code)]
 
@@ -14,6 +14,6 @@ pub mod serialize;
 pub use arrow2_convert_derive::{ArrowDeserialize, ArrowField, ArrowSerialize};
 
 // Test README with doctests
-#[doc = include_str!("../README.md")]
+#[cfg_attr(not(target_os = "windows"), doc = include_str!("../README.md"))]
 #[cfg(doctest)]
 struct ReadmeDoctests;

--- a/arrow2_convert/tests/test_deserialize.rs
+++ b/arrow2_convert/tests/test_deserialize.rs
@@ -1,5 +1,5 @@
-use arrow2::array::*;
 use arrow2::error::Result;
+use arrow2::{array::*, buffer::Buffer};
 use arrow2_convert::{deserialize::*, serialize::*, ArrowDeserialize, ArrowField, ArrowSerialize};
 
 #[test]
@@ -76,4 +76,14 @@ fn test_deserialize_large_types_schema_mismatch_error() {
 
     let result: Result<Vec<S2>> = arr1.try_into_collection();
     assert!(result.is_err());
+}
+
+#[test]
+fn test_deserialize_buffer() {
+    let original_array = [Buffer::from_iter(0u16..5), Buffer::from_iter(7..9)];
+    let b: Box<dyn Array> = original_array.try_into_arrow().unwrap();
+    let iter = arrow_array_deserialize_iterator::<Buffer<u16>>(b.as_ref()).unwrap();
+    for (i, k) in iter.zip(original_array.iter()) {
+        assert_eq!(&i, k);
+    }
 }

--- a/arrow2_convert/tests/test_serialize.rs
+++ b/arrow2_convert/tests/test_serialize.rs
@@ -1,4 +1,5 @@
 use arrow2::array::Array;
+use arrow2::buffer::Buffer;
 use arrow2::chunk::Chunk;
 use arrow2_convert::field::{ArrowField, FixedSizeBinary};
 use arrow2_convert::serialize::*;
@@ -67,6 +68,23 @@ fn test_array() {
     let r: Arc<dyn Array> = strs.try_into_arrow().unwrap();
     assert_eq!(r.len(), 1);
     assert_eq!(r.data_type(), &<Vec<u8> as ArrowField>::data_type());
+}
+
+#[test]
+fn test_buffer() {
+    // Buffer<u8> and Vec<u8> should serialize into BinaryArray
+    let dat: Vec<Buffer<u8>> = vec![(0..10).into_iter().collect()];
+    let r: Box<dyn Array> = dat.try_into_arrow().unwrap();
+    assert_eq!(r.len(), 1);
+    assert_eq!(r.data_type(), &<Buffer<u8> as ArrowField>::data_type());
+    assert_eq!(r.data_type(), &<Vec<u8> as ArrowField>::data_type());
+
+    // Buffer<u16> and Vec<u16> should serialize into ListArray
+    let dat: Vec<Buffer<u16>> = vec![(0..10).into_iter().collect()];
+    let r: Box<dyn Array> = dat.try_into_arrow().unwrap();
+    assert_eq!(r.len(), 1);
+    assert_eq!(r.data_type(), &<Buffer<u16> as ArrowField>::data_type());
+    assert_eq!(r.data_type(), &<Vec<u16> as ArrowField>::data_type());
 }
 
 #[test]


### PR DESCRIPTION
Serializing and deserializing a `Buffer<T>` is **much** faster than a `Vec<T>`, as the added benchmark shows:

```
serialize/Buffer/1000    time:   [669.72 ns 672.49 ns 675.58 ns]
serialize/Vec/1000       time:   [3.2616 µs 3.2665 µs 3.2722 µs]

deserialize/Buffer/10000 time:   [380.00 ns 382.86 ns 385.58 ns]
deserialize/Vec/10000    time:   [6.6530 µs 6.6782 µs 6.7093 µs]
```