### PR TITLE
Fix serialization issue with nested unions

### DIFF
--- a/arrow2_convert/tests/test_enum.rs
+++ b/arrow2_convert/tests/test_enum.rs
@@ -57,7 +57,18 @@ fn test_nested_unit_variant() {
 
     #[derive(Debug, PartialEq, ArrowField, ArrowSerialize, ArrowDeserialize)]
     #[arrow_field(type = "dense")]
-    enum TestEnum {
+    enum TestDenseEnum {
+        VAL1,
+        VAL2(i32),
+        VAL3(f64),
+        VAL4(TestStruct),
+        VAL5(DenseChildEnum),
+        VAL6(SparseChildEnum),
+    }
+
+    #[derive(Debug, PartialEq, ArrowField, ArrowSerialize, ArrowDeserialize)]
+    #[arrow_field(type = "sparse")]
+    enum TestSparseEnum {
         VAL1,
         VAL2(i32),
         VAL3(f64),
@@ -85,16 +96,29 @@ fn test_nested_unit_variant() {
     }
 
     let enums = vec![
-        TestEnum::VAL1,
-        TestEnum::VAL2(2),
-        TestEnum::VAL3(1.2),
-        TestEnum::VAL4(TestStruct { a1: 10 }),
-        TestEnum::VAL5(DenseChildEnum::VAL4(TestStruct { a1: 42 })),
-        TestEnum::VAL6(SparseChildEnum::VAL4(TestStruct { a1: 42 })),
+        TestDenseEnum::VAL1,
+        TestDenseEnum::VAL2(2),
+        TestDenseEnum::VAL3(1.2),
+        TestDenseEnum::VAL4(TestStruct { a1: 10 }),
+        TestDenseEnum::VAL5(DenseChildEnum::VAL4(TestStruct { a1: 17 })),
+        TestDenseEnum::VAL6(SparseChildEnum::VAL4(TestStruct { a1: 42 })),
     ];
 
     let b: Box<dyn Array> = enums.try_into_arrow().unwrap();
-    let round_trip: Vec<TestEnum> = b.try_into_collection().unwrap();
+    let round_trip: Vec<TestDenseEnum> = b.try_into_collection().unwrap();
+    assert_eq!(round_trip, enums);
+
+    let enums = vec![
+        TestSparseEnum::VAL1,
+        TestSparseEnum::VAL2(2),
+        TestSparseEnum::VAL3(1.2),
+        TestSparseEnum::VAL4(TestStruct { a1: 10 }),
+        TestSparseEnum::VAL5(DenseChildEnum::VAL4(TestStruct { a1: 17 })),
+        TestSparseEnum::VAL6(SparseChildEnum::VAL4(TestStruct { a1: 42 })),
+    ];
+
+    let b: Box<dyn Array> = enums.try_into_arrow().unwrap();
+    let round_trip: Vec<TestSparseEnum> = b.try_into_collection().unwrap();
     assert_eq!(round_trip, enums);
 }
 

--- a/arrow2_convert/tests/test_enum.rs
+++ b/arrow2_convert/tests/test_enum.rs
@@ -62,12 +62,22 @@ fn test_nested_unit_variant() {
         VAL2(i32),
         VAL3(f64),
         VAL4(TestStruct),
-        VAL5(ChildEnum),
+        VAL5(DenseChildEnum),
+        VAL6(SparseChildEnum),
+    }
+
+    #[derive(Debug, PartialEq, ArrowField, ArrowSerialize, ArrowDeserialize)]
+    #[arrow_field(type = "dense")]
+    enum DenseChildEnum {
+        VAL1,
+        VAL2(i32),
+        VAL3(f64),
+        VAL4(TestStruct),
     }
 
     #[derive(Debug, PartialEq, ArrowField, ArrowSerialize, ArrowDeserialize)]
     #[arrow_field(type = "sparse")]
-    enum ChildEnum {
+    enum SparseChildEnum {
         VAL1,
         VAL2(i32),
         VAL3(f64),
@@ -79,6 +89,8 @@ fn test_nested_unit_variant() {
         TestEnum::VAL2(2),
         TestEnum::VAL3(1.2),
         TestEnum::VAL4(TestStruct { a1: 10 }),
+        TestEnum::VAL5(DenseChildEnum::VAL4(TestStruct{a1: 42})),
+        TestEnum::VAL6(SparseChildEnum::VAL4(TestStruct{a1: 42}))
     ];
 
     let b: Box<dyn Array> = enums.try_into_arrow().unwrap();

--- a/arrow2_convert/tests/test_enum.rs
+++ b/arrow2_convert/tests/test_enum.rs
@@ -89,8 +89,8 @@ fn test_nested_unit_variant() {
         TestEnum::VAL2(2),
         TestEnum::VAL3(1.2),
         TestEnum::VAL4(TestStruct { a1: 10 }),
-        TestEnum::VAL5(DenseChildEnum::VAL4(TestStruct{a1: 42})),
-        TestEnum::VAL6(SparseChildEnum::VAL4(TestStruct{a1: 42}))
+        TestEnum::VAL5(DenseChildEnum::VAL4(TestStruct { a1: 42 })),
+        TestEnum::VAL6(SparseChildEnum::VAL4(TestStruct { a1: 42 })),
     ];
 
     let b: Box<dyn Array> = enums.try_into_arrow().unwrap();

--- a/arrow2_convert/tests/test_serialize.rs
+++ b/arrow2_convert/tests/test_serialize.rs
@@ -73,14 +73,14 @@ fn test_array() {
 #[test]
 fn test_buffer() {
     // Buffer<u8> and Vec<u8> should serialize into BinaryArray
-    let dat: Vec<Buffer<u8>> = vec![(0..10).into_iter().collect()];
+    let dat: Vec<Buffer<u8>> = vec![(0..10).collect()];
     let r: Box<dyn Array> = dat.try_into_arrow().unwrap();
     assert_eq!(r.len(), 1);
     assert_eq!(r.data_type(), &<Buffer<u8> as ArrowField>::data_type());
     assert_eq!(r.data_type(), &<Vec<u8> as ArrowField>::data_type());
 
     // Buffer<u16> and Vec<u16> should serialize into ListArray
-    let dat: Vec<Buffer<u16>> = vec![(0..10).into_iter().collect()];
+    let dat: Vec<Buffer<u16>> = vec![(0..10).collect()];
     let r: Box<dyn Array> = dat.try_into_arrow().unwrap();
     assert_eq!(r.len(), 1);
     assert_eq!(r.data_type(), &<Buffer<u16> as ArrowField>::data_type());

--- a/arrow2_convert/tests/ui/struct_incorrect_type.stderr
+++ b/arrow2_convert/tests/ui/struct_incorrect_type.stderr
@@ -11,7 +11,7 @@ error[E0308]: mismatched types
  --> tests/ui/struct_incorrect_type.rs:4:45
   |
 4 | #[derive(Debug, ArrowField, ArrowSerialize, ArrowDeserialize)]
-  |                                             ^^^^^^^^^^^^^^^^ expected struct `String`, found struct `Vec`
+  |                                             ^^^^^^^^^^^^^^^^ expected `String`, found `Vec<u8>`
   |
   = note: expected struct `String`
              found struct `Vec<u8>`

--- a/arrow2_convert_derive/src/derive_enum.rs
+++ b/arrow2_convert_derive/src/derive_enum.rs
@@ -313,7 +313,7 @@ pub fn expand_serialize(input: DeriveEnum) -> TokenStream {
             }
 
             fn len(&self) -> usize {
-                self.#first_variant.len()
+                self.types.len()
             }
 
             fn validity(&self) -> Option<&arrow2::bitmap::MutableBitmap> {

--- a/arrow2_convert_derive/src/derive_enum.rs
+++ b/arrow2_convert_derive/src/derive_enum.rs
@@ -119,7 +119,6 @@ pub fn expand_serialize(input: DeriveEnum) -> TokenStream {
         ..
     } = (&input).into();
 
-    let first_variant = &variant_names[0];
     let is_dense = input.is_dense;
 
     let mutable_array_name = &input.common.mutable_array_name();
@@ -227,6 +226,7 @@ pub fn expand_serialize(input: DeriveEnum) -> TokenStream {
         let first_name = &variant_names[0];
         quote! {
             self.types.push(0);
+            self.offsets.push((self.#first_name.len()) as i32);
             <#first_array_type as MutableArray>::push_null(&mut self.#first_name);
         }
     } else {


### PR DESCRIPTION
I believe this is both a repro and fix for: https://github.com/DataEngineeringLabs/arrow2-convert/issues/86

The implementation of len() was only appropriate for Sparse unions, but I believe using `.types()` is actually correct here.