### PR TITLE
Fix link on symlinked README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The Arrow ecosystem provides many ways to convert between Arrow and other popula
 
 The example below performs a round trip conversion of a struct with a single field. 
 
-Please see the [complex_example.rs](./arrow2_convert/tests/complex_example.rs) for usage of the full functionality.
+Please see the [complex_example.rs](https://github.com/DataEngineeringLabs/arrow2-convert/blob/main/arrow2_convert/tests/complex_example.rs) for usage of the full functionality.
 
 ```rust
 /// Simple example


### PR DESCRIPTION
The README.md file in the directory arrow2_convert_derive is a symlink to this README.md file, however the link is broken if I click from that directory. The link once results in: `https://github.com/DataEngineeringLabs/arrow2-convert/blob/main/arrow2_convert_derive/arrow2_convert/tests/complex_example.rs` which is a 404.

I think the same happened to me when I clicked on the docs.rs

Making the link absolute to try to fix the current 404 I get when I try to follow the link.